### PR TITLE
fix: use context manager for file read in wandb_util

### DIFF
--- a/turbodiffusion/imaginaire/utils/wandb_util.py
+++ b/turbodiffusion/imaginaire/utils/wandb_util.py
@@ -89,7 +89,8 @@ def _read_wandb_id(config_job: JobConfig, config_checkpoint: CheckpointConfig) -
     wandb_id = None
     wandb_id_path = f"{config_job.path_local}/wandb_id.txt"
     if os.path.isfile(wandb_id_path):
-        wandb_id = open(wandb_id_path).read().strip()
+        with open(wandb_id_path) as f:
+            wandb_id = f.read().strip()
     return wandb_id
 
 


### PR DESCRIPTION
Replace `open(path).read()` with `with open(path) as f: f.read()` in `wandb_util.py` to ensure the file descriptor is promptly closed instead of relying on garbage collection.