### PR TITLE
Add TurboT2AV SageSLA, FastNorm, and W8A8 acceleration submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "turbodiffusion/ops/cutlass"]
 	path = turbodiffusion/ops/cutlass
 	url = https://github.com/NVIDIA/cutlass
+[submodule "TurboT2AV"]
+	path = TurboT2AV
+	url = https://github.com/liuyuxiang1021/turbo-t2av.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "TurboT2AV"]
 	path = TurboT2AV
 	url = https://github.com/liuyuxiang1021/turbo-t2av.git
-	branch = main
+	branch = w8a8-5090-test

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "TurboT2AV"]
 	path = TurboT2AV
 	url = https://github.com/liuyuxiang1021/turbo-t2av.git
-	branch = w8a8-5090-test
+	branch = main


### PR DESCRIPTION
## Summary

This PR adds TurboT2AV as an optional TurboDiffusion submodule for accelerated text-to-audio-video inference.

The submodule `main` branch is based on the clean `origin_inference` branch and contains inference-only integration:

- SageAttention and SLA/SageSLA adapters for selected LTX self-attention modules
- FastNorm replacements for module and functional norm paths, plus fused modulation, residual, and RoPE helpers
- W8A8 Linear support with TurboDiffusion's strict prequantized backend and an H20-oriented TileLang post-scale backend
- attention scope, SLA top-k, resolution override, timing, and prequantized-checkpoint CLI controls
- a reproducible H20 latency breakdown and a documented speed/quality tradeoff

Training scripts, training workflow changes, and trained SLA adapter checkpoints are not included.

## Defaults

The original inference behavior remains the CLI default:

- `--attention_type default`
- `--fast_norm` disabled
- `--quant_linear` disabled
- `--sla_topk 1.0` when SLA/SageSLA is selected without an explicit ratio

The recommended accelerated command is opt-in and uses self-attention SageSLA with `topk=0.3`, FastNorm, and TileLang W8A8 Linear.

## Cumulative H20 validation

The breakdown follows TurboDiffusion's cumulative order: optimize the teacher with W8A8/FastNorm, switch to the rCM-distilled student while retaining those optimizations, and finally add SageSLA. Generator-only measurements use one NVIDIA H20, `1024x1792`, 121 frames, and `--skip_decode`.

| Stage | Generator latency | Speedup vs previous | Speedup vs teacher |
| --- | ---: | ---: | ---: |
| LTX-2-19B teacher (40 steps) | 318.7405s/video | - | 1.00x |
| + W8A8 and FastNorm | 233.3424s/video | 1.37x | 1.37x |
| + rCM (4-step student) | 11.7628s/video | 19.84x | 27.10x |
| + SageSLA `topk=0.3` | 5.8689s/video | 2.00x | 54.31x |

The long teacher rows use one measured generation; student rows report medians from repeated generations. The non-cumulative pure 4-step student takes 16.1096s/video, making the final path 2.75x faster than the pure student as well.

At this resolution the video latent contains 28,672 self-attention tokens. Component checks measured SageSLA self-attention at 4.82x over SDPA and the two dominant TileLang W8A8 FFN GEMM shapes at 1.56x and 1.61x over BF16.

`topk=0.3` is the documented high-resolution speed/quality tradeoff based on decoded prompt comparisons. SageSLA is approximate sparse attention, so lower ratios can change generated content more visibly.

## Submodule

- Repository: `liuyuxiang1021/turbo-t2av`
- Branch: `main`
- Current commit: `b57fb9bbbe92324b1aebc5b7e5b17ded3538aa8d`
- Clean inference base: `origin_inference` at `c99f03b7b615661f63513b3816ea6c62b754c5ce`

The parent `.gitmodules` entry tracks the submodule's `main` branch, while the gitlink pins the exact commit above.

## Validation

- `git diff --check`
- Python byte-compilation of the acceleration, FastNorm, TileLang W8A8, prequantization, inference-runner, and plotting modules
- regenerated and inspected the 1024x1792 acceleration figure
- verified both local worktrees match their pushed remote branches
- scanned submitted files for tokens, proxy settings, and workspace-local secret paths
